### PR TITLE
:arrow_up: Bump edilkamin from 1.5.0 to 1.6.0

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "assert": "^2.0.0",
     "axios": "^1.13.2",
     "bootstrap": "^5.3.8",
-    "edilkamin": "^1.5.0",
+    "edilkamin": "^1.6.2",
     "i18next": "^25.7.2",
     "next": "^16",
     "next-i18next": "^15.4.3",

--- a/src/__tests__/pages/api/proxy/[...params].test.ts
+++ b/src/__tests__/pages/api/proxy/[...params].test.ts
@@ -3,10 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "../../../../pages/api/proxy/[...params]";
 
-// Mock edilkamin to get API_URL
+// Mock edilkamin to get OLD_API_URL (used by proxy handler)
 vi.mock("edilkamin", () => ({
   API_URL: "https://api.edilkamin.com/",
+  OLD_API_URL:
+    "https://fxtj7xkgc6.execute-api.eu-central-1.amazonaws.com/prod/",
 }));
+
+// Constants for test assertions (must match mock values above)
+const OLD_API_URL =
+  "https://fxtj7xkgc6.execute-api.eu-central-1.amazonaws.com/prod/";
 
 describe("API Proxy Handler", () => {
   let mockFetch: ReturnType<typeof vi.fn>;
@@ -55,7 +61,7 @@ describe("API Proxy Handler", () => {
     await handler(req as NextApiRequest, res as NextApiResponse);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.edilkamin.com/devices/abc123",
+      `${OLD_API_URL}devices/abc123`,
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
@@ -87,7 +93,7 @@ describe("API Proxy Handler", () => {
     await handler(req as NextApiRequest, res as NextApiResponse);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.edilkamin.com/devices/abc123/power",
+      `${OLD_API_URL}devices/abc123/power`,
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify(requestBody),
@@ -113,7 +119,7 @@ describe("API Proxy Handler", () => {
     await handler(req as NextApiRequest, res as NextApiResponse);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.edilkamin.com/devices/aabbcc/status/details",
+      `${OLD_API_URL}devices/aabbcc/status/details`,
       expect.any(Object),
     );
   });
@@ -185,11 +191,8 @@ describe("API Proxy Handler", () => {
 
     await handler(req, res as NextApiResponse);
 
-    // Should fallback to empty array and just use API_URL
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.edilkamin.com/",
-      expect.any(Object),
-    );
+    // Should fallback to empty array and just use OLD_API_URL
+    expect(mockFetch).toHaveBeenCalledWith(OLD_API_URL, expect.any(Object));
   });
 
   it("should not include body in GET request", async () => {

--- a/src/__tests__/pages/fireplace/[mac].test.tsx
+++ b/src/__tests__/pages/fireplace/[mac].test.tsx
@@ -16,6 +16,8 @@ vi.mock("edilkamin", () => ({
     setTargetTemperature: vi.fn(),
   })),
   API_URL: "https://api.edilkamin.com/",
+  OLD_API_URL:
+    "https://fxtj7xkgc6.execute-api.eu-central-1.amazonaws.com/prod/",
 }));
 
 // Mock axios for error type checking

--- a/src/pages/api/proxy/[...params].ts
+++ b/src/pages/api/proxy/[...params].ts
@@ -1,4 +1,4 @@
-import { API_URL } from "edilkamin";
+import { OLD_API_URL as API_URL } from "edilkamin";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const handler = async (

--- a/src/test/__mocks__/edilkamin.ts
+++ b/src/test/__mocks__/edilkamin.ts
@@ -10,8 +10,10 @@ export const configure = vi.fn(() => ({
   setTargetTemperature: vi.fn(),
 }));
 
-// Mock API_URL constant
+// Mock API_URL constants
 export const API_URL = "https://api.edilkamin.com/";
+export const OLD_API_URL =
+  "https://fxtj7xkgc6.execute-api.eu-central-1.amazonaws.com/prod/";
 
 // Re-export types (will use actual types from edilkamin)
 export * from "edilkamin";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2807,13 +2807,6 @@ axe-core@^4.10.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.2.tgz#85228e3e1d8b8532a27659b332e39b7fa0e022df"
   integrity sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==
 
-axios@^0.26.0:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
-  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
-  dependencies:
-    follow-redirects "^1.14.8"
-
 axios@^1.13.2:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.2.tgz#9ada120b7b5ab24509553ec3e40123521117f687"
@@ -3242,13 +3235,14 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
-edilkamin@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/edilkamin/-/edilkamin-1.5.0.tgz#cf8e2a059147d5b9d5fc193f5324b34f8e1c00a7"
-  integrity sha512-Tv6Xw73Iqgj88ukc66guLrCQNPM38oQb8c2SlnnoJL4XL+y9faYXxtvMlAggUnnZQyEM7TcPWp2cx6O1+oEfqg==
+edilkamin@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/edilkamin/-/edilkamin-1.6.2.tgz#36ee59f266c7744fd3845f08510688ebaefd71f3"
+  integrity sha512-LGJEuCTgs6nFMqZqXSmV14KBiUwXNJUUgRynHu2WwH1efPX3rXu6XOy0R2C+QCYrEdQUhatBdA77phHQZ64I/Q==
   dependencies:
     aws-amplify "^6.10.0"
-    axios "^0.26.0"
+    axios "^1.13.2"
+    pako "^2.1.0"
   optionalDependencies:
     commander "^12.1.0"
 
@@ -3877,7 +3871,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.2.tgz#adba1448a9841bec72b42c532ea23dbbedef1a27"
   integrity sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==
 
-follow-redirects@^1.14.8, follow-redirects@^1.15.6:
+follow-redirects@^1.15.6:
   version "1.15.11"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
@@ -5095,6 +5089,11 @@ package-json-from-dist@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
+pako@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 parent-module@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Update to edilkamin 1.6.0 which includes internal API changes to work with Edilkamin's updated backend (new endpoint and idToken-based authentication).